### PR TITLE
use -v flag with drmc

### DIFF
--- a/bash_profile.sh
+++ b/bash_profile.sh
@@ -49,7 +49,7 @@ dssh() {
 alias drun="docker-compose run web"
 alias dash="docker-compose run web /bin/bash"
 alias dkill="docker kill \$(docker ps -q)"
-alias drmc="docker rm \$(docker ps -aq)"
+alias drmc="docker rm -v \$(docker ps -aq)"
 alias drmi="docker rmi \$(docker images -q)"
 
 eval "$(docker-machine env default)"


### PR DESCRIPTION
According to this: https://github.com/docker-library/mysql/issues/40#issuecomment-69738884

If we dont use `-v` the volumes never get deleted